### PR TITLE
fix: AVX-512 compilation and test failures with multi-feature targets

### DIFF
--- a/curve25519-dalek-derive/src/lib.rs
+++ b/curve25519-dalek-derive/src/lib.rs
@@ -402,7 +402,21 @@ fn process_function(
             }
             syn::Meta::Path(path) if is_path_eq(path, "test") => {
                 maybe_outer_attributes.push(attribute);
-                maybe_cfg = quote::quote! { #[cfg(target_feature = #attributes)] };
+                // Split comma-separated features and generate proper cfg
+                let attr_value = attributes.value();
+                let features: Vec<_> = attr_value
+                    .split(',')
+                    .map(|f| f.trim().to_string())
+                    .collect();
+                if features.len() == 1 {
+                    let feature = &features[0];
+                    maybe_cfg = quote::quote! { #[cfg(target_feature = #feature)] };
+                } else {
+                    let feature_cfgs = features.iter().map(|f| {
+                        quote::quote! { target_feature = #f }
+                    });
+                    maybe_cfg = quote::quote! { #[cfg(all(#(#feature_cfgs),*))] };
+                }
             }
             syn::Meta::List(syn::MetaList { path, tokens, .. })
                 if is_path_eq(path, "inline") && tokens.to_string() == "always" =>

--- a/curve25519-dalek-derive/tests/tests.rs
+++ b/curve25519-dalek-derive/tests/tests.rs
@@ -99,23 +99,32 @@ mod inner_spec {
     }
 
     #[for_target_feature("sse2")]
-    const IS_AVX2: bool = false;
+    pub const IS_AVX2: bool = false;
 
     #[for_target_feature("avx2")]
-    const IS_AVX2: bool = true;
+    pub const IS_AVX2: bool = true;
 
+    #[for_target_feature("sse2")]
     #[test]
     fn test_specialized() {
         assert!(!IS_AVX2);
     }
 
-    #[cfg(test)]
-    mod tests {
-        #[test]
-        fn test_specialized_inner() {
-            assert!(!super::IS_AVX2);
-        }
+    #[for_target_feature("avx2")]
+    #[test]
+    fn test_specialized() {
+        assert!(IS_AVX2);
     }
+}
+
+#[test]
+fn test_specialized_inner_sse2() {
+    assert!(!inner_spec_sse2::IS_AVX2);
+}
+
+#[test]
+fn test_specialized_inner_avx2() {
+    assert!(inner_spec_avx2::IS_AVX2);
 }
 
 #[unsafe_target_feature("sse2")]

--- a/curve25519-dalek/Cargo.toml
+++ b/curve25519-dalek/Cargo.toml
@@ -88,4 +88,5 @@ check-cfg = [
     'cfg(curve25519_dalek_diagnostics, values("build"))',
     'cfg(curve25519_dalek_bits, values("32", "64"))',
     'cfg(nightly)',
+    'cfg(target_feature, values("avx512ifma,avx512vl"))',
 ]

--- a/curve25519-dalek/src/backend.rs
+++ b/curve25519-dalek/src/backend.rs
@@ -46,14 +46,14 @@ pub mod vector;
 enum BackendKind {
     #[cfg(curve25519_dalek_backend = "simd")]
     Avx2,
-    #[cfg(curve25519_dalek_backend = "avx512")]
+    #[cfg(all(curve25519_dalek_backend = "avx512", target_feature = "avx512ifma", target_feature = "avx512vl"))]
     Avx512,
     Serial,
 }
 
 #[inline]
 fn get_selected_backend() -> BackendKind {
-    #[cfg(curve25519_dalek_backend = "avx512")]
+    #[cfg(all(curve25519_dalek_backend = "avx512", target_feature = "avx512ifma", target_feature = "avx512vl"))]
     {
         cpufeatures::new!(cpuid_avx512, "avx512ifma", "avx512vl");
         let token_avx512: cpuid_avx512::InitToken = cpuid_avx512::init();
@@ -88,7 +88,7 @@ where
         #[cfg(curve25519_dalek_backend = "simd")]
         BackendKind::Avx2 =>
             vector::scalar_mul::pippenger::spec_avx2::Pippenger::optional_multiscalar_mul::<I, J>(scalars, points),
-        #[cfg(curve25519_dalek_backend = "avx512")]
+        #[cfg(all(curve25519_dalek_backend = "avx512", target_feature = "avx512ifma", target_feature = "avx512vl"))]
         BackendKind::Avx512 =>
             vector::scalar_mul::pippenger::spec_avx512ifma_avx512vl::Pippenger::optional_multiscalar_mul::<I, J>(scalars, points),
         BackendKind::Serial =>
@@ -100,7 +100,7 @@ where
 pub(crate) enum VartimePrecomputedStraus {
     #[cfg(curve25519_dalek_backend = "simd")]
     Avx2(vector::scalar_mul::precomputed_straus::spec_avx2::VartimePrecomputedStraus),
-    #[cfg(curve25519_dalek_backend = "avx512")]
+    #[cfg(all(curve25519_dalek_backend = "avx512", target_feature = "avx512ifma", target_feature = "avx512vl"))]
     Avx512ifma(
         vector::scalar_mul::precomputed_straus::spec_avx512ifma_avx512vl::VartimePrecomputedStraus,
     ),
@@ -120,7 +120,7 @@ impl VartimePrecomputedStraus {
             #[cfg(curve25519_dalek_backend = "simd")]
             BackendKind::Avx2 =>
                 VartimePrecomputedStraus::Avx2(vector::scalar_mul::precomputed_straus::spec_avx2::VartimePrecomputedStraus::new(static_points)),
-            #[cfg(curve25519_dalek_backend = "avx512")]
+            #[cfg(all(curve25519_dalek_backend = "avx512", target_feature = "avx512ifma", target_feature = "avx512vl"))]
             BackendKind::Avx512 =>
                 VartimePrecomputedStraus::Avx512ifma(vector::scalar_mul::precomputed_straus::spec_avx512ifma_avx512vl::VartimePrecomputedStraus::new(static_points)),
             BackendKind::Serial =>
@@ -135,7 +135,7 @@ impl VartimePrecomputedStraus {
         match self {
             #[cfg(curve25519_dalek_backend = "simd")]
             VartimePrecomputedStraus::Avx2(inner) => inner.len(),
-            #[cfg(curve25519_dalek_backend = "avx512")]
+            #[cfg(all(curve25519_dalek_backend = "avx512", target_feature = "avx512ifma", target_feature = "avx512vl"))]
             VartimePrecomputedStraus::Avx512ifma(inner) => inner.len(),
             VartimePrecomputedStraus::Scalar(inner) => inner.len(),
         }
@@ -148,7 +148,7 @@ impl VartimePrecomputedStraus {
         match self {
             #[cfg(curve25519_dalek_backend = "simd")]
             VartimePrecomputedStraus::Avx2(inner) => inner.is_empty(),
-            #[cfg(curve25519_dalek_backend = "avx512")]
+            #[cfg(all(curve25519_dalek_backend = "avx512", target_feature = "avx512ifma", target_feature = "avx512vl"))]
             VartimePrecomputedStraus::Avx512ifma(inner) => inner.is_empty(),
             VartimePrecomputedStraus::Scalar(inner) => inner.is_empty(),
         }
@@ -176,7 +176,7 @@ impl VartimePrecomputedStraus {
                 dynamic_scalars,
                 dynamic_points,
             ),
-            #[cfg(curve25519_dalek_backend = "avx512")]
+            #[cfg(all(curve25519_dalek_backend = "avx512", target_feature = "avx512ifma", target_feature = "avx512vl"))]
             VartimePrecomputedStraus::Avx512ifma(inner) => inner.optional_mixed_multiscalar_mul(
                 static_scalars,
                 dynamic_scalars,
@@ -207,7 +207,7 @@ where
         BackendKind::Avx2 => {
             vector::scalar_mul::straus::spec_avx2::Straus::multiscalar_mul::<I, J>(scalars, points)
         }
-        #[cfg(curve25519_dalek_backend = "avx512")]
+        #[cfg(all(curve25519_dalek_backend = "avx512", target_feature = "avx512ifma", target_feature = "avx512vl"))]
         BackendKind::Avx512 => {
             vector::scalar_mul::straus::spec_avx512ifma_avx512vl::Straus::multiscalar_mul::<I, J>(
                 scalars, points,
@@ -236,7 +236,7 @@ where
                 scalars, points,
             )
         }
-        #[cfg(curve25519_dalek_backend = "avx512")]
+        #[cfg(all(curve25519_dalek_backend = "avx512", target_feature = "avx512ifma", target_feature = "avx512vl"))]
         BackendKind::Avx512 => {
             vector::scalar_mul::straus::spec_avx512ifma_avx512vl::Straus::optional_multiscalar_mul::<
                 I,
@@ -254,7 +254,7 @@ pub fn variable_base_mul(point: &EdwardsPoint, scalar: &Scalar) -> EdwardsPoint 
     match get_selected_backend() {
         #[cfg(curve25519_dalek_backend = "simd")]
         BackendKind::Avx2 => vector::scalar_mul::variable_base::spec_avx2::mul(point, scalar),
-        #[cfg(curve25519_dalek_backend = "avx512")]
+        #[cfg(all(curve25519_dalek_backend = "avx512", target_feature = "avx512ifma", target_feature = "avx512vl"))]
         BackendKind::Avx512 => {
             vector::scalar_mul::variable_base::spec_avx512ifma_avx512vl::mul(point, scalar)
         }
@@ -268,7 +268,7 @@ pub fn vartime_double_base_mul(a: &Scalar, A: &EdwardsPoint, b: &Scalar) -> Edwa
     match get_selected_backend() {
         #[cfg(curve25519_dalek_backend = "simd")]
         BackendKind::Avx2 => vector::scalar_mul::vartime_double_base::spec_avx2::mul(a, A, b),
-        #[cfg(curve25519_dalek_backend = "avx512")]
+        #[cfg(all(curve25519_dalek_backend = "avx512", target_feature = "avx512ifma", target_feature = "avx512vl"))]
         BackendKind::Avx512 => {
             vector::scalar_mul::vartime_double_base::spec_avx512ifma_avx512vl::mul(a, A, b)
         }


### PR DESCRIPTION

## Issues Fixed

### 1. Macro generates invalid cfg for multi-feature test functions
The `#[unsafe_target_feature]` macro generated invalid cfg attributes for comma-separated features:
- **Before:** `#[cfg(target_feature = "avx512ifma,avx512vl")]` (invalid)
- **After:** `#[cfg(all(target_feature = "avx512ifma", target_feature = "avx512vl"))]`

### 2. Specialized test assertions were incorrect
Tests in `inner_spec` always asserted `!IS_AVX2`, which failed when AVX2 was enabled at compile time. Now each specialization asserts the correct value.

### 3. Doc-test compilation mismatch
References to `spec_avx512ifma_avx512vl` modules in `backend.rs` were guarded only by `curve25519_dalek_backend = "avx512"`, but the modules themselves also require target features. This caused doc-tests to fail. Now both use matching cfg conditions.

## Changes

- `curve25519-dalek-derive/src/lib.rs`: Split comma-separated features when generating test cfg
- `curve25519-dalek-derive/tests/tests.rs`: Fix test assertions with `#[for_target_feature]`
- `curve25519-dalek/src/backend.rs`: Align cfg guards with module availability
- `curve25519-dalek/Cargo.toml`: Add check-cfg entry for macro-generated value

## Testing

All tests pass with and without AVX-512 flags:
- `cargo test --release` ✅
- `RUSTFLAGS="-C target_feature=+avx512ifma,+avx512vl" cargo test --release` ✅